### PR TITLE
Providing RDV server as environment variable or cli arg

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -117,14 +117,19 @@ An RDV server account must now have been reserved and configured on the RDV serv
 The tunnelling device must now be configured to use the UNIX account, so that the scripts will authenticate using that account username.
 In order to do this, add a line in file `~/.profile`, that will set the appropriate environment variable:
 
-For a master RPI, for example, if the username created on the RDV server is `rpi1111`:
+For a master RPI, for example, if the username created on the RDV server is *rpi1111*:
 ```
 export MASTERDEV_USERNAME=rpi1111
 ```
 
-For an onsite RPI, , for example, if the username created on the RDV server is `rpi1108`:
+For an onsite RPI, , for example, if the username created on the RDV server is *rpi1108*:
 ```
 export ONSITEDEV_USERNAME=rpi1108
+```
+
+Also, add a line that will provide the IP address or hostname of the RDV server:
+```
+export RDV_SERVER_HOSTNAME=my.rdv.server.com
 ```
 
 Once these environment variables configured, close the current shell and reopen it. You should see this variable set in the new shell, check this by running:
@@ -136,9 +141,22 @@ printenv | grep _USERNAME=
 
 This step allows us to make sure that the public key of the RPI has been properly associated with a valid account on the RDV server.
 
-In the following example, we are testing that a RPI using username `rpi1111` can connect to a RDV server 88.23.6.77. From a terminal on the RPI, run:
+In the following example, we are testing that an onsite RPI can connect to the RDV server.
+`RDV_SERVER_HOSTNAME` has been set in `~/.profile` above and is now available as an environment variable to the shell.
+`ONSITEDEV_USERNAME` or `MASTERDEV_USERNAME` is also available as an environment variable.
+
+From a terminal on the onsite RPI, run:
 ```
-ssh rpi1111@88.23.6.77
+ssh $ONSITEDEV_USERNAME@$RDV_SERVER_HOSTNAME
+```
+For an onsite RPI using username *rpi1108* and a configured RDV server *my.rdv.server.com*, this is equivalent to:
+```
+ssh rpi1108@my.rdv.server.com
+```
+
+Or for a master RPI, run:
+```
+ssh $MASTERDEV_USERNAME@$RDV_SERVER_HOSTNAME
 ```
 
 If this connection works properly, you can directly run the automated tunnelling device script (first in directly over ssh, without stunnel, which may not work if your firewall drops outgoing ssh connections on port 22):

--- a/masterdev_script.py
+++ b/masterdev_script.py
@@ -83,11 +83,13 @@ if __name__ == '__main__':
     DBUS_SERVICE_INTERFACE = 'com.legrandelectric.RemoteAccess.SecondaryIfWatcher'	# The name of the D-Bus service under which we will perform input/output on D-Bus
     
     username_env = os.getenv('MASTERDEV_USERNAME', None)	# By default, take username from environment
+    rdv_server_env = os.getenv('RDV_SERVER_HOSTNAME', None)       # By default, take RDV server hostname from environment
     
     # Parse arguments
     parser = argparse.ArgumentParser(description="This program automatically connects to a RDV server as a master device. \
 and automates the typing of tundev shell commands from the tunnelling devices side in order to setup a tunnel session", prog=progname)
     parser.add_argument('-u', '--username', help='user account to use when connecting to the RDV server (can also be provided using env var MASTERDEV_USERNAME)', required=(username_env is None), default=username_env)	# This will override environment if provided, if no environment variable is provided, this argument becomes mandatory
+    parser.add_argument('-R', '--rdv-server', dest='rdv_server', help='hostname or IP address for the RDV server to connect to (can also be provided using env var RDV_SERVER_HOSTNAME)', required=(rdv_server_env is None), default=rdv_server_env)       # This will override environment if provided, if no environment variable is provided, this argument becomes mandatory
     parser.add_argument('-d', '--debug', action='store_true', help='display debug info', default=False)
     parser.add_argument('-T', '--with-stunnel', dest='with_stunnel', action='store_true', help='connect to RDVServer throught local stunnel instead of directly through SSH', default=False)
     parser.add_argument('-l', '--list-onsite', dest='list_onsite', action='store_true', help='lists the currently available onsite devices')
@@ -115,7 +117,7 @@ and automates the typing of tundev shell commands from the tunnelling devices si
     logger.debug('Starting as PID ' + str(os.getpid()))
     
     username = args.username
-    master_dev = MasterDev(username=username, logger=logger)
+    master_dev = MasterDev(username=username, logger=logger, rdv_server=args.rdv_server)
     
     msg = 'Connecting to RDV server'
     if args.with_stunnel:

--- a/onsite-fs/init.d/onsitedevscript
+++ b/onsite-fs/init.d/onsitedevscript
@@ -14,7 +14,7 @@
 #                    as long as this service is running)
 ### END INIT INFO
 
-DAEMON="/home/pi/tunnelling-dev-scripts/onsitedev_script.sh" #ligne de commande du programme
+DAEMON="/home/pi/remote-access-tunnelling-dev/onsitedev_script.sh" #ligne de commande du programme
 daemon_OPT=""  #argument à utiliser par le programme
 DAEMONUSER="root" #utilisateur du programme
 daemon_NAME="onsitedevscript" #Nom du programme (doit être identique à l'exécutable)

--- a/onsitedev_script.py
+++ b/onsitedev_script.py
@@ -54,11 +54,13 @@ class OnsiteDev(tundev_script.TunnellingDev):
 
 if __name__ == '__main__':
     username_env = os.getenv('ONSITEDEV_USERNAME', None)       # By default, take username from environment
+    rdv_server_env = os.getenv('RDV_SERVER_HOSTNAME', None)       # By default, take RDV server hostname from environment
     
     # Parse arguments
     parser = argparse.ArgumentParser(description="This program automatically connects to a RDV server as an onsite device. \
 and automates the typing of tundev shell commands from the tunnelling devices side in order to setup a tunnel session", prog=progname)
     parser.add_argument('-u', '--username', help='user account to use when connecting to the RDV server (can also be provided using env var ONSITEDEV_USERNAME)', required=(username_env is None), default=username_env)       # This will override environment if provided, if no environment variable is provided, this argument becomes mandatory
+    parser.add_argument('-R', '--rdv-server', dest='rdv_server', help='hostname or IP address for the RDV server to connect to (can also be provided using env var RDV_SERVER_HOSTNAME)', required=(rdv_server_env is None), default=rdv_server_env)       # This will override environment if provided, if no environment variable is provided, this argument becomes mandatory
     parser.add_argument('-d', '--debug', action='store_true', help='display debug info', default=False)
     parser.add_argument('-T', '--with-stunnel', dest='with_stunnel', action='store_true', help='connect to RDVServer throught local stunnel instead of directly through SSH', default=False)
     parser.add_argument('-t', '--session-time', type=int, dest='session_time', help='specify session duration (in seconds)', default=-1)
@@ -92,7 +94,7 @@ and automates the typing of tundev shell commands from the tunnelling devices si
         pid_file.close()
         
     username = args.username
-    onsite_dev = OnsiteDev(username=username, logger=logger)
+    onsite_dev = OnsiteDev(username=username, logger=logger, rdv_server=args.rdv_server)
     
     if not args.uplink_dev is None:  # We must add the specific route to the rdv server before we execute rdv_server_connect()
         onsite_dev.add_host_route(host_ip=onsite_dev.get_rdv_server(), iface=args.uplink_dev, ip_use_sudo=True)

--- a/tundev_script.py
+++ b/tundev_script.py
@@ -27,13 +27,13 @@ class TunnellingDev(object):
     A tunnelling device is a abstract device gathering client devices or server devices
     """
     
-    PROTO_RDV_SERVER = '0.0.0.0'	# Note: changing this will only affect behaviour in direct (no -T) mode, for SSL tunnelled mode (-T), the IP address of the RDV server is configured in stunnel's config files
     SSH_ESCAPE_SHELL_PROMPT = 'ssh> '
                 
-    def __init__(self, username, logger, rdv_server = PROTO_RDV_SERVER, key_filename = None, prompt = None):
+    def __init__(self, username, logger, rdv_server, key_filename = None, prompt = None):
         """ Constructor
         \param username The username to use with ssh to connect to the RDV server
         \param logger A logging.Logger to use for log messages
+        \param rdv_server The hostname of IP address of the RDV server to connect to (this will only affect behaviour in direct (no -T) mode, for SSL tunnelled mode (-T), the IP address of the RDV server is configured in stunnel's config files)
         \param key_filename A file containing the private key for key-based ssh authentication
         \param prompt The expected prompt (if None, will be built from the username) 
         """


### PR DESCRIPTION
Avoid having it hardcoded in python code. Closes third issue from the bottom of the TODO list.